### PR TITLE
Bump version to 2.2.0 and remove obsolete script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Artifact fetching and publishing use a chain-of-responsibility pattern:
 
 Each fetched artifact is tagged with an `ItemSource` (SAVANT or MAVEN) via a `FetchResult` record. This controls publish routing:
 
-- `CacheProcess(output, savantDir, mavenDir)` — Manages both Savant and Maven caches. Fetch tries savantDir first (SAVANT), then mavenDir (MAVEN). Publish routes SAVANT items to savantDir, MAVEN items to mavenDir. Either dir can be null.
+- `CacheProcess(output, savantDir, integrationDir, mavenDir)` — Manages Savant, integration, and Maven caches. Fetch tries integrationDir first for integration versions, then savantDir (SAVANT), then mavenDir (MAVEN). Publish routes integration items to integrationDir, SAVANT items to savantDir, MAVEN items to mavenDir. Any dir can be null.
 - `URLProcess` tags items as `SAVANT`; `MavenProcess` tags items as `MAVEN`
 
 Maven POMs are translated to `ArtifactMetaData` in-memory (no AMD files written for Maven-sourced artifacts).

--- a/build.savant
+++ b/build.savant
@@ -13,8 +13,8 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-savantVersion = "2.1.0"
-project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.1.0", licenses: ["Apache-2.0"]) {
+savantVersion = "2.2.0-{integration}"
+project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.2.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/shell/release-int.sh
+++ b/src/main/shell/release-int.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-name="savant-dependency-management"
-version="0.2.0-{integration}"
-cp src/main/resources/amd.xml ~/.savant/cache/org/savantbuild/${name}/${version}/${name}-${version}.jar.amd
-cd ~/.savant/cache/org/savantbuild/${name}/${version}/
-md5sum ${name}-${version}.jar > ${name}-${version}.jar.md5
-md5sum ${name}-${version}.jar.amd > ${name}-${version}.jar.amd.md5
-md5sum ${name}-${version}-src.jar > ${name}-${version}-src.jar.md5


### PR DESCRIPTION
## Summary
- Version bump to 2.2.0 as part of the XDG Base Directory migration across all core libraries
- Remove obsolete `release-int.sh` script (referenced version 0.2.0, hardcoded `~/.savant/cache`)

## Test plan
- [x] `sb test` passes (87 tests, 0 failures)